### PR TITLE
fix typo of hoc import

### DIFF
--- a/src/components/Feedbacks.jsx
+++ b/src/components/Feedbacks.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 
 import { styles } from '../styles';
-import { SectionsWrapper } from '../hoc';
+import { SectionsWrapper } from '../HOC';
 import { fadeIn, textVariant } from '../utils/motion';
 import { testimonials } from '../constants';
 


### PR DESCRIPTION
## Description

There was an hoc import typo i fixed it from './hoc' to "./HOC".
@syket-git please review
